### PR TITLE
Bug Fix for Apache 2.x user running mod_vhost_alias

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -7,7 +7,7 @@ defined('DS') || define('DS' , DIRECTORY_SEPARATOR);
 // Folder where munee is located
 defined('MUNEE_FOLDER') || define('MUNEE_FOLDER', dirname(__DIR__));
 // Define Webroot if hasn't already been defined
-defined('WEBROOT') || define('WEBROOT', $_SERVER['DOCUMENT_ROOT']);
+defined('WEBROOT') || define('WEBROOT', str_replace($_SERVER['SCRIPT_NAME'], '', $_SERVER['SCRIPT_FILENAME']));
 // Define the cache path
 defined('MUNEE_CACHE') || define('MUNEE_CACHE', MUNEE_FOLDER . DS . 'cache');
 


### PR DESCRIPTION
Replaced $_SERVER['DOCUMENT_ROOT'] with str_replace($_SERVER['SCRIPT_NAME'], '', $_SERVER['SCRIPT_FILENAME']) to fix bug with vhost_alias in Apache 2.x
