### PR TITLE
Remove CoffeeScript-PHP header

### DIFF
--- a/src/Munee/Asset/Type/JavaScript.php
+++ b/src/Munee/Asset/Type/JavaScript.php
@@ -38,7 +38,7 @@ class JavaScript extends Type
     protected function _beforeFilter($originalFile, $cacheFile)
     {
         if ('coffee' == pathinfo($originalFile, PATHINFO_EXTENSION)) {
-            $coffeeScript = CoffeeScript\Compiler::compile(file_get_contents($originalFile));
+            $coffeeScript = CoffeeScript\Compiler::compile(file_get_contents($originalFile), array('header' => false));
             file_put_contents($cacheFile, $coffeeScript);
         }
     }


### PR DESCRIPTION
I've changed the header option to false when compiling CoffeeScript.

Tiny change really, feel free to reject, but I figure displaying the version has potential to expose security issues, is really only relevant for debugging, and adds a few bytes to the file.. might as well drop it

This time with the right branches.. I think (sorry for the trouble :eyes: )
