### PR TITLE
Changes to Munee package.

### DIFF
--- a/src/Munee/Asset/HeaderSetter.php
+++ b/src/Munee/Asset/HeaderSetter.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Munee: Optimising Your Assets
+ *
+ * @copyright Cody Lundquist 2013
+ * @license http://opensource.org/licenses/mit-license.php
+ */
+
+namespace Munee\Asset;
+
+/**
+ * Handles setting HTTP headers.
+ *
+ * @author Terence C
+ */
+class HeaderSetter
+{
+    /**
+     * Set HTTP status code.
+     *
+     * @param string $protocol
+     * @param string $code
+     * @param string $message
+     * 
+     * @return object
+     */
+    public function statusCode($protocol, $code, $message)
+    {
+        header("{$protocol} {$code} {$message}");
+        
+        return $this;
+    }
+    
+    /**
+     * Set HTTP header field/value.
+     *
+     * @param string $field
+     * @param string $value
+     * 
+     * @return object
+     */
+    public function headerField($field, $value)
+    {
+        header("{$field}: {$value}");
+        
+        return $this;
+    }
+}

--- a/src/Munee/Asset/Type.php
+++ b/src/Munee/Asset/Type.php
@@ -54,6 +54,11 @@ abstract class Type
      * @var object
      */
     protected $_request;
+    
+    /**
+     * @var object
+     */
+    public $_response;
 
     /**
      * Constructor
@@ -182,7 +187,7 @@ abstract class Type
     {
         // Check if the file exists
         if (! file_exists($originalFile)) {
-            throw new NotFoundException('File does not exist: ' . str_replace(WEBROOT, '', $originalFile));
+            throw new NotFoundException('File does not exist: ' . str_replace($this->_request->docroot, '', $originalFile));
         }
 
         // Copy the original file to the cache location

--- a/src/Munee/Asset/Type/Css.php
+++ b/src/Munee/Asset/Type/Css.php
@@ -32,7 +32,7 @@ class Css extends Type
      */
     public function getHeaders()
     {
-        header("Content-Type: text/css");
+        $this->_response->headerController->headerField('Content-Type', 'text/css');
     }
 
     /**
@@ -153,7 +153,13 @@ class Css extends Type
         $regEx = '%(background(?:-image)?:.*?url[\\s]*\()[\\s\'"]*(\.\.[^\\)\'"]*)[\\s\'"]*(\\)[\\s]*)%';
 
         $changedContent = preg_replace_callback($regEx, function($match) use ($originalFile) {
-            $basePath = str_replace(WEBROOT, '', dirname($originalFile)) . '/' . trim($match[2]);
+            
+            $basePathPrefix = str_replace($this->_request->docroot, '', dirname($originalFile));
+            
+            if($basePathPrefix)
+                $basePathPrefix .= '/';
+            
+            $basePath = $basePathPrefix . trim($match[2]);
             $count = 1;
             while ($count > 0) {
                 $basePath = preg_replace('%\\w+/\\.\\./%', '', $basePath, -1, $count);

--- a/src/Munee/Asset/Type/Image.php
+++ b/src/Munee/Asset/Type/Image.php
@@ -104,13 +104,13 @@ class Image extends Type
         switch ($this->_request->ext) {
             case 'jpg':
             case 'jpeg':
-                header("Content-Type: image/jpg");
+                $this->_response->headerController->headerField('Content-Type', 'image/jpg');
                 break;
             case 'png':
-                header("Content-Type: image/png");
+                $this->_response->headerController->headerField('Content-Type', 'image/png');
                 break;
             case 'gif':
-                header("Content-Type: image/gif");
+                $this->_response->headerController->headerField('Content-Type', 'image/gif');
                 break;
         }
     }
@@ -175,7 +175,7 @@ class Image extends Type
 
             foreach ($this->_options['placeholders'] as $path => $placeholder) {
                 // Setup path for regex
-                $regex = '^' . WEBROOT . str_replace(array('*', WEBROOT), array('.*?', ''), $path) . '$';
+                $regex = '^' . $this->_request->docroot . str_replace(array('*', $this->_request->docroot), array('.*?', ''), $path) . '$';
                 if (preg_match("%{$regex}%", $file)) {
                     if ('http' == substr($placeholder, 0, 4)) {
                         $ret = $this->_getImageByUrl($placeholder);

--- a/src/Munee/Asset/Type/JavaScript.php
+++ b/src/Munee/Asset/Type/JavaScript.php
@@ -23,7 +23,7 @@ class JavaScript extends Type
      */
     public function getHeaders()
     {
-        header("Content-Type: text/javascript");
+        $this->_response->headerController->headerField('Content-Type', 'text/javascript');
     }
 
 

--- a/src/Munee/Dispatcher.php
+++ b/src/Munee/Dispatcher.php
@@ -39,6 +39,13 @@ class Dispatcher
      */
     public static function run(Request $Request, $options = array())
     {
+        /**
+         * Set the header controller.
+         */
+        $header_controller = (isset($options['headerController']) && $options['headerController'] instanceof Asset\HeaderSetter)
+                                ? $options['headerController']
+                                : new Asset\HeaderSetter;
+
         try {
             /**
              * Merge in default options
@@ -64,6 +71,13 @@ class Dispatcher
              * Set the headers if told to do so
              */
             if ($options['setHeaders']) {
+                /**
+                 * Set the header controller for response.
+                 */
+                $Response->setHeaderController($header_controller);
+                /**
+                 * Set the headers.
+                 */
                 $Response->setHeaders();
             }
             /**
@@ -72,8 +86,8 @@ class Dispatcher
              */
             return $Response->notModified ? null : $Response->render();
         } catch (Asset\NotFoundException $e) {
-            header("HTTP/1.0 404 Not Found");
-            header("Status: 404 Not Found");
+            $header_controller->statusCode('HTTP/1.0', 404, 'Not Found');
+            $header_controller->headerField('Status', 404, 'Not Found');
             return 'Error: ' . $e->getMessage();
         } catch (ErrorException $e) {
             return 'Error: ' . $e->getMessage();

--- a/tests/Munee/Cases/RequestTest.php
+++ b/tests/Munee/Cases/RequestTest.php
@@ -66,12 +66,13 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      * Make sure files are parsed properly and the extension is set
      */
     public function testInit()
-    {
-        $Request = new Request();
-
+    {        
         $_GET = array(
             'files' => '/js/foo.js,/js/bar.js'
         );
+        
+        $Request = new Request();
+
         $Request->init();
 
         $this->assertSame('js', $Request->ext);
@@ -83,11 +84,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testExtensionNotSupported()
     {
-        $Request = new Request();
-
         $_GET = array(
             'files' => '/js/foo.jpg,/js/bar.js'
         );
+        
+        $Request = new Request();
 
         $this->setExpectedException('Munee\ErrorException');
         $Request->init();
@@ -98,11 +99,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testGoingAboveWebroot()
     {
-        $Request = new Request();
-
         $_GET = array(
             'files' => '/../..././js/bad.js,/js/bar.js'
         );
+
+        $Request = new Request();
 
         $Request->init();
         $this->assertSame(array(WEBROOT . '/js/bad.js', WEBROOT . '/js/bar.js'), $Request->files);
@@ -113,11 +114,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testLegacyCode()
     {
-        $Request = new Request();
-
         $_GET = array(
             'files' => '/minify/js/foo.js'
         );
+
+        $Request = new Request();
 
         $Request->init();
 
@@ -130,13 +131,13 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetRawParams()
     {
-        $Request = new Request();
-
         $_GET = array(
             'files' => '/js/foo.js,/js/bar.js',
             'minify' => 'true',
             'notAllowedParam' => 'foo'
         );
+
+        $Request = new Request();
 
         $Request->init();
         $rawParams = $Request->getRawParams();
@@ -148,8 +149,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseParams()
     {
-        $Request = new Request();
-
         $_GET = array(
             'files' => '/js/foo.js,/js/bar.js',
             'foo' => 'true',
@@ -157,6 +156,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             'notAllowedParam' => 'foo'
 
         );
+
+        $Request = new Request();
 
         $Request->init();
 
@@ -201,12 +202,12 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testWrongParamValue()
     {
-        $Request = new Request();
-
         $_GET = array(
             'files' => '/js/foo.js',
             'foo' => 'not good'
         );
+
+        $Request = new Request();
 
         $Request->init();
 


### PR DESCRIPTION
- Made "WEBROOT" more flexible; it's now able to be set through a setDocroot method.
- Removed $_GET dependency and unpredictable alteration of $_GET variables.
- Added setFiles method to set file path(s) without needing $_GET['files'].
- HTTP headers are no longer set directly through PHP's header() function, but instead go through a (configurable) HeaderSetter class or subclass.
- Due to the addition of 'docroot', the CSS _fixRelativeImagePaths had to be changed to prevent bugs when LESS/other files were outside of the web root - though I don't see why this method is needed at all.
- Updated unit tests as applicable to the above changes.

Signed-off-by: tcopestake terence.copestake@gmail.com
