### PR TITLE
Replace relative paths with absolute paths for list-style-image

### DIFF
--- a/src/Munee/Asset/Type/Css.php
+++ b/src/Munee/Asset/Type/Css.php
@@ -150,7 +150,7 @@ class Css extends Type
      */
     protected function _fixRelativeImagePaths($content, $originalFile)
     {
-        $regEx = '%(background(?:-image)?:.*?url[\\s]*\()[\\s\'"]*(\.\.[^\\)\'"]*)[\\s\'"]*(\\)[\\s]*)%';
+        $regEx = '%((?:background(?:-image)?|list-style-image):.*?url[\\s]*\()[\\s\'"]*(\.\.[^\\)\'"]*)[\\s\'"]*(\\)[\\s]*)%';
 
         $changedContent = preg_replace_callback($regEx, function($match) use ($originalFile) {
             $basePath = str_replace(WEBROOT, '', dirname($originalFile)) . '/' . trim($match[2]);


### PR DESCRIPTION
Changed regex to allow for replacing relative paths with absolute paths in css for the `list-style-image` css property in addition to `background` and `background-image`.
