### PR TITLE
Allow for uppercased asset extensions

### DIFF
--- a/src/Munee/Request.php
+++ b/src/Munee/Request.php
@@ -147,7 +147,7 @@ class Request
             $this->setRawParam('minify', 'true');
         }
 
-        $this->ext = pathinfo($this->rawFiles, PATHINFO_EXTENSION);
+        $this->ext = strtolower(pathinfo($this->rawFiles, PATHINFO_EXTENSION));
         $supportedExtensions = Registry::getSupportedExtensions($this->ext);
         // Suppressing errors because Exceptions thrown in the callback cause Warnings.
         $webroot = $this->webroot;


### PR DESCRIPTION
On user managed websites, .JPG and .GIF files are often uploaded. This change will allow for such files to be processed.
