### PR TITLE
Don't minify if filename have .min in it

### DIFF
--- a/src/Munee/Asset/Type.php
+++ b/src/Munee/Asset/Type.php
@@ -232,7 +232,7 @@ abstract class Type
             if (! is_array($arguments)) {
                 $arguments = array($filterName => $arguments);
             }
-            if(strpos($originalFile, '.min') !== FALSE) {
+            if(strpos($originalFile, '.min.') !== FALSE) {
                 $arguments['minify'] = false;
             }
             $Filter->doFilter($cacheFile, $arguments, $this->options);


### PR DESCRIPTION
Sometimes minifying javascript file which already is minified, cause problems.
