### PR TITLE
For meenie/munee#51

### DIFF
--- a/src/Munee/Asset/Filter/Css/Minify.php
+++ b/src/Munee/Asset/Filter/Css/Minify.php
@@ -68,7 +68,7 @@ class Minify extends Filter
     {
         $regexs = array(
             // Remove Comments
-            '%/\*[^*]*\*+([^/][^*]*\*+)*/%',
+            '%/\*[^*!]*\*+([^/][^*]*\*+)*/%',
             // Fixing extra spacing between classes so there is only one space
             '%(\w)\s{2,}\.%',
         );


### PR DESCRIPTION
This will still remove some whitespace characters, however it will prevent the holly hack from being removed:

~~~css
/*! Set property for ie6 on PC only, not ie5 mac \*/
* html #menu li {height:1%}
/*! end hide ie5 mac */
~~~