### PR TITLE
[WIP] travis: PHP 5.5+ added, run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,18 @@
 language: php
+
 php:
-  - 5.4
   - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+
+matrix:
+  allow_failures:
+    - php: 7.0
+
+before_script:
+  - composer install
+
+script:
+  - phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="tests/bootstrap.php">
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+>
     <testsuites>
         <testsuite name="Munee Test Suite">
             <directory>./tests/Munee/</directory>

--- a/tests/Munee/Cases/ResponseTest.php
+++ b/tests/Munee/Cases/ResponseTest.php
@@ -55,7 +55,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($checkHeaders['Cache-Control'], $setHeaders['Cache-Control']);
         unset($setHeaders['Cache-Control']);
-        $this->assertSame($checkHeaders['Content-Type'], $setHeaders['Content-Type']);
+        $this->assertContains($checkHeaders['Content-Type'], $setHeaders['Content-Type']);
         unset($setHeaders['Content-Type']);
         $this->assertSame($checkHeaders['Last-Modified'], $setHeaders['Last-Modified']);
         unset($setHeaders['Last-Modified']);
@@ -127,7 +127,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($checkHeaders['Cache-Control'], $setHeaders['Cache-Control']);
         unset($setHeaders['Cache-Control']);
-        $this->assertSame($checkHeaders['Content-Type'], $setHeaders['Content-Type']);
+        $this->assertContains($checkHeaders['Content-Type'], $setHeaders['Content-Type']);
         unset($setHeaders['Content-Type']);
         $this->assertSame($checkHeaders['Last-Modified'], $setHeaders['Last-Modified']);
         unset($setHeaders['Last-Modified']);
@@ -166,6 +166,10 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         foreach ($rawHeaders as $header) {
             $headerParts = explode(':', $header, 2);
             if (2 == count($headerParts)) {
+                if ($headerParts[0] === 'Content-type') {
+                    // xdebug incompatible naming
+                    $headerParts[0] = 'Content-Type';
+                }
                 $ret[$headerParts[0]] = trim($headerParts[1]);
             } elseif (isset($ret[$headerParts[0]])) {
                 // If a header param is empty, make sure others with the same name are not set as well


### PR DESCRIPTION
For PHP 7 it fails due to missing xdebug - maybe add some check to tests?

For PHP 5.6 it fails due to [missing Content-type](https://travis-ci.org/meenie/munee/jobs/54392566#L201). Probably modified internal method. - I'm working on it