### PR TITLE
composer: use PSR-4, drop unused phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         }
     ],
     "autoload": {
-        "psr-0": {
-            "Munee": "src/"
+        "psr-4": {
+            "Munee\\": "src/Munee"
         },
         "files": ["config/bootstrap.php"]
     },
@@ -26,8 +26,5 @@
         "coffeescript/coffeescript": "1.3.1",
         "meenie/javascript-packer": "1.1",
         "tubalmartin/cssmin": "~2.4"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "3.7.*"
     }
 }


### PR DESCRIPTION
- [PSR-0 is deprecated](http://www.php-fig.org/psr/psr-0/) for since 2014-10
- PHPUnit is not needed in composer anymore (I understand this is opinion based; PHPUnit has ~20 deprendencies, that are downloaded for every build for no use)