### PR TITLE
Update some packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "leafo/lessphp": "0.5.0",
+        "oyejorge/less.php": "1.7.0.5",
         "leafo/scssphp": "0.1.1",
         "tedivm/jshrink": "1.0.1",
         "imagine/imagine": "0.6.2",
         "coffeescript/coffeescript": "1.3.1",
         "meenie/javascript-packer": "1.1",
         "tubalmartin/cssmin": "~2.4",
-        "sabberworm/php-css-parser": "~6.0"
+        "sabberworm/php-css-parser": "7.0.0"
     }
 }


### PR DESCRIPTION
1. It seems that [lessphp is officially dead](https://github.com/leafo/lessphp/issues/543) - it even can`t compile Bootstrap 3! So i suggest you to replace it to oyejorge/less.php. We already use it in MODX component [MinifyX](https://github.com/bezumkin/MinifyX) and it works great! 

2. Version 6.0.0 of sabberworm/php-css-parser [fails on PHP 5.3.3](https://github.com/sabberworm/PHP-CSS-Parser/issues/83), so i changed it to dev-master.