### PR TITLE
Font type created

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -45,3 +45,10 @@ Registry::register(array('js', 'coffee'), function (\Munee\Request $Request) {
 Registry::register(array('jpg', 'jpeg', 'gif', 'png'), function (\Munee\Request $Request) {
     return new \Munee\Asset\Type\Image($Request);
 });
+
+/**
+ * Register the Font Asset Class with the extensions .ttf, .otf, .woff, .woff2 and .eot
+ */
+Registry::register(array('ttf', 'otf', 'woff', 'woff2', 'eot'), function (\Munee\Request $Request) {
+    return new \Munee\Asset\Type\Font($Request);
+});

--- a/src/Munee/Asset/Type/Font.php
+++ b/src/Munee/Asset/Type/Font.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Munee: Optimising Your Assets
+ *
+ * @copyright Cody Lundquist 2013
+ * @license http://opensource.org/licenses/mit-license.php
+ */
+
+namespace Munee\Asset\Type;
+
+use Munee\Asset\Type;
+use CoffeeScript;
+
+/**
+ * Handles Font files
+ *
+ * @author Gregory Goijaers
+ */
+class Font extends Type
+{
+    /**
+     * Set headers for Font
+     */
+    public function getHeaders()
+    {
+        $this->response->headerController->headerField('Content-Type', 'application/x-opentype');
+        // TODO check if the header is correct
+    }
+
+}


### PR DESCRIPTION
This should fix the font-encoding issue for libraries like Font-Awesome. All it does is return the font-file and it stops Munee from returning the "Error: The following extension is not handled: woff2" error.
#91
