### PR TITLE
Update sabberworm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
         "coffeescript/coffeescript": "1.3.1",
         "meenie/javascript-packer": "1.1",
         "tubalmartin/cssmin": "~2.4",
-        "sabberworm/php-css-parser": "7.0.0"
+        "sabberworm/php-css-parser": "7.0.3"
     }
 }


### PR DESCRIPTION
Latest sabberworm/php-css-parser fixes PHP 7 error "Cannot use Sabberworm\\CSS\\Value\\String as String because 'String' is a special class name"
https://github.com/bezumkin/MinifyX/issues/21