### PR TITLE
fix response content-type header: image/jpeg instead of image/jpg

### DIFF
--- a/src/Munee/Asset/Type/Image.php
+++ b/src/Munee/Asset/Type/Image.php
@@ -112,7 +112,7 @@ class Image extends Type
         switch ($this->request->ext) {
             case 'jpg':
             case 'jpeg':
-                $this->response->headerController->headerField('Content-Type', 'image/jpg');
+                $this->response->headerController->headerField('Content-Type', 'image/jpeg');
                 break;
             case 'png':
                 $this->response->headerController->headerField('Content-Type', 'image/png');


### PR DESCRIPTION
When I use server side image resizing with monee, I get response with header Content-Type: image/jpg but most of the client libraries are waiting for Content-Type: image/jpeg (for example famous iOS library https://github.com/Alamofire/AlamofireImage)

source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types